### PR TITLE
"Add to Home Screen" icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,8 @@
   <link rel="shortcut icon" type="image/x-icon" href="falcon_high_res2.png" />
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="mobile-web-app-capable" content="yes">
+  <link rel="apple-touch-icon" sizes="128x128" href="falcon_high_res2.png" />
+  <link rel="icon" sizes="192x192" href="falcon_high_res2.png">
   
   <script src="ServerDate.js"></script>
 </head>


### PR DESCRIPTION
This commit adds an icon for the "Add to Home Screen" popup (see issue #40). I have included lines of code for both iOS and Android, but I have only tested on iOS.

Screenshots:
![1301B48A-3DD5-45FA-8C45-3B85AF9B1F41](https://user-images.githubusercontent.com/45520974/54860149-5dba6400-4cec-11e9-8111-5c4e1ec53701.png)
![36F3C0C3-CCA4-4D77-A97F-1D86CF0283A9](https://user-images.githubusercontent.com/45520974/54860145-54c99280-4cec-11e9-8000-50b966e25e2b.png)
![image3](https://user-images.githubusercontent.com/45520974/54860176-d5888e80-4cec-11e9-891f-1f5044c36488.png)

